### PR TITLE
chore: rename package from `dapi` to `d-api`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Build
+        run: npm run build
+
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple library to create complex systems out of pure functions
 ## Installation
 
 ```bash
-npm install -D dapi
+npm install -D d-api
 ```
 
 ## Usage
@@ -15,7 +15,7 @@ npm install -D dapi
 To create an `DapiWrapper` you need to create an [`DapiDefinition`](#dapidefinition) object and pass it to the [`createDapi`](#createdapi) factory function.
 
 ```Typescript
-import {createDapi} from 'dapi';
+import {createDapi} from 'd-api';
 
 type Dependencies = {
   db: OracleClient,
@@ -153,7 +153,7 @@ export const createCustomer = async (
 Ideally you should pass a `createUser` fn with its dependencies already set to the `createCustomer` fn. This way, the `createCustomer` fn does not need to know about the dependencies of the `createPerson` fn. It only needs to know about the dependencies it needs to do its job.
 
 ```Typescript
-import {createDapi, DapiFn} from 'dapi';
+import {createDapi, DapiFn} from 'd-api';
 import type {DapiUser, UserData} from './user';
 import type {Logger} from './logger';
 import type {RabbitMQ} from './mqBroker';
@@ -435,7 +435,7 @@ Adds a decorator to a `DapiFn` of the `DapiWrapper` instance.
 **Example**
 
 ```Typescript
-import {createDapi} from 'dapi';
+import {createDapi} from 'd-api';
 import {profile} from './profiler';
 import {createPerson} from './person';
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "dapi",
+  "name": "d-api",
   "version": "0.1.0",
   "description": "Simple library to create complex systems out of pure functions",
   "main": "./dist/cjs/index.js",
   "module": "./dist/cjs/index.mjs",
-  "type": "module",
+  "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",
   "exports": {
     ".": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @module dapi
+ * @module d-api
  */
 export {DapiMixin, type DapiDefinition, type DapiWrapper} from './DapiMixin';
 export {createDapi} from './createDapi';


### PR DESCRIPTION
there is already a `dapi` package in npm registry