### PR TITLE
chore: add name-scope to library name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple library to create complex systems out of pure functions
 ## Installation
 
 ```bash
-npm install -D d-api
+npm install -D @carpasse/dapi
 ```
 
 ## Usage
@@ -15,7 +15,7 @@ npm install -D d-api
 To create an `DapiWrapper` you need to create an [`DapiDefinition`](#dapidefinition) object and pass it to the [`createDapi`](#createdapi) factory function.
 
 ```Typescript
-import {createDapi} from 'd-api';
+import {createDapi} from '@carpasse/';
 
 type Dependencies = {
   db: OracleClient,
@@ -153,7 +153,7 @@ export const createCustomer = async (
 Ideally you should pass a `createUser` fn with its dependencies already set to the `createCustomer` fn. This way, the `createCustomer` fn does not need to know about the dependencies of the `createPerson` fn. It only needs to know about the dependencies it needs to do its job.
 
 ```Typescript
-import {createDapi, DapiFn} from 'd-api';
+import {createDapi, DapiFn} from '@carpasse/';
 import type {DapiUser, UserData} from './user';
 import type {Logger} from './logger';
 import type {RabbitMQ} from './mqBroker';
@@ -435,7 +435,7 @@ Adds a decorator to a `DapiFn` of the `DapiWrapper` instance.
 **Example**
 
 ```Typescript
-import {createDapi} from 'd-api';
+import {createDapi} from '@carpasse/';
 import {profile} from './profiler';
 import {createPerson} from './person';
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "d-api",
+  "name": "@carpasse/dapi",
   "version": "0.1.0",
   "description": "Simple library to create complex systems out of pure functions",
   "main": "./dist/cjs/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @module d-api
+ * @module @carpasse/dapi
  */
 export {DapiMixin, type DapiDefinition, type DapiWrapper} from './DapiMixin';
 export {createDapi} from './createDapi';


### PR DESCRIPTION
I thought a lot about it and I don't want to have to deal with name collisions of any kind. I think it is best to name-scope all my packages