### PR TITLE
feat: add decorateAll & getDefinition methods to DapiWrapper class

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,16 @@ The class also allows to decorate the Dapi functions with decorators and hooks.
 
 #### Methods
 
+##### `getDefinition`
+
+`DapiDefinition` getter.
+
+**Syntax**:
+
+```Typescript
+getDefinition(): DapiDefinition<DEPENDENCIES, DAPI>
+```
+
 ##### `getDependencies`
 
 Dependencies getter.
@@ -470,6 +480,27 @@ Removes a decorator from the `DapiWrapper` instance.
 
 - `key` - The name of the decorated method. Must be a key of the [`DapiDefinition.fns`](#dapidefinition) fns dictionary.
 - `decorator` - The decorator function to be removed from the method.
+
+##### `decorateAll`
+
+Decorates all the `DapiDefinition.fns` with the passed decorator.
+
+**Syntax**:
+
+```Typescript
+  decorateAll(decorator: DecoratorFn<DAPI[keyof DAPI], DapiWrapper>): () => void
+```
+
+**Parameters**:
+
+- `decorator` - The decorator function to be added to the method. Each decorator must accept the following arguments
+  - `fn` - The function to be decorated.
+  - `deps` - The dependencies of the [`DapiDefinition.fns`](#dapidefinition).
+  - `args` - The arguments passed to the method.
+
+**Returns**:
+
+- Function to remove the all the added that accepts no arguments.
 
 ##### `addHook`
 

--- a/src/DapiMixin.ts
+++ b/src/DapiMixin.ts
@@ -198,6 +198,15 @@ export function DapiMixin<DEPENDENCIES, DAPI extends DapiFns<DEPENDENCIES>, T ex
     }
 
     /**
+     * DapiDefinition getter.
+     *
+     * @returns DapiDefinition
+     */
+    getDefinition() {
+      return this.__definition;
+    }
+
+    /**
      * Returns a JSON representation of the `DapiWrapper` instance.
      * @param replacer An array of strings and numbers that acts as an approved list for selecting the object properties that will be stringified.
      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
@@ -238,6 +247,25 @@ export function DapiMixin<DEPENDENCIES, DAPI extends DapiFns<DEPENDENCIES>, T ex
 
       return () => {
         this.removeDecorator(key, decorator);
+      };
+    }
+
+    /**
+     * Decorates all the Dapi functions of the `DapiWrapper`'s Dapi functions dictionary.
+     * @param decorator The decorator function. The decorator function receives the decorated function as its first argument and the rest of the arguments are the arguments of the decorated function.
+     * @returns A function to remove all the added decorators.
+     */
+    decorateAll(decorator: DecoratorFn<DAPI[keyof DAPI], DapiWrapper>) {
+      const removeDecorators: (() => void)[] = [];
+
+      for (const key of Object.keys(this.__definition.fns)) {
+        removeDecorators.push(this.addDecorator(key as keyof DAPI, decorator));
+      }
+
+      return () => {
+        for (const removeDecorator of removeDecorators) {
+          removeDecorator();
+        }
       };
     }
 


### PR DESCRIPTION
Add a method to be able to decorate all DAPI fns at once and a method to get the DAPI definition