### PR TITLE
refactor: do not type check the first param of a dapi fn before extra…

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Returns a JSON representation of the `DapiWrapper` instance.
 **Syntax**:
 
 ```Typescript
-  toJSON(...args: ParamsExtract<JSON['stringify'], [Parameters<JSON['stringify']>[0]]>)
+  toJSON(...args: ExtractFirstParam<JSON['stringify'], [Parameters<JSON['stringify']>[0]]>)
 ```
 
 **Parameters**:

--- a/src/DapiMixin.ts
+++ b/src/DapiMixin.ts
@@ -1,4 +1,4 @@
-import {Constructor, ParamsExtract} from './types/utils';
+import {Constructor, ExtractFirstParam} from './types/utils';
 import {DapiFns, DecoratorFn, HookFn} from './types';
 
 /**
@@ -52,7 +52,7 @@ export function DapiMixin<DEPENDENCIES, DAPI extends DapiFns<DEPENDENCIES>, T ex
     };
   };
   type Facade = {
-    [key in keyof DAPI]: (...args: ParamsExtract<DAPI[key], [DEPENDENCIES]>) => ReturnType<DAPI[key]>;
+    [key in keyof DAPI]: (...args: ExtractFirstParam<DAPI[key]>) => ReturnType<DAPI[key]>;
   };
 
   /**
@@ -90,7 +90,7 @@ export function DapiMixin<DEPENDENCIES, DAPI extends DapiFns<DEPENDENCIES>, T ex
 
       for (const key of Object.keys(fns)) {
         // @ts-expect-error - tried to define an index signature but it didn't work
-        this[key] = (...params: ParamsExtract<DAPI[typeof key], [DEPENDENCIES]>) => {
+        this[key] = (...params: ExtractFirstParam<DAPI[typeof key], [DEPENDENCIES]>) => {
           return this.__facade[key](...params);
         };
       }
@@ -102,7 +102,7 @@ export function DapiMixin<DEPENDENCIES, DAPI extends DapiFns<DEPENDENCIES>, T ex
       for (const entry of Object.entries(fns)) {
         const [key, command] = entry as [keyof DAPI, (typeof fns)[keyof DAPI]];
 
-        facade[key] = (...params: ParamsExtract<DAPI[typeof key], [DEPENDENCIES]>) => {
+        facade[key] = (...params: ExtractFirstParam<DAPI[typeof key]>) => {
           return command.call(this, this.__deps, ...params);
         };
       }
@@ -117,7 +117,7 @@ export function DapiMixin<DEPENDENCIES, DAPI extends DapiFns<DEPENDENCIES>, T ex
 
       const command = this.__definition.fns[key];
 
-      this.__facade[key] = (...params: ParamsExtract<DAPI[typeof key], [DEPENDENCIES]>) => {
+      this.__facade[key] = (...params: ExtractFirstParam<DAPI[typeof key]>) => {
         const decoratorFns = this.decorators[key];
         const decorators = [...(decoratorFns ?? [])];
         const hookDecorator = this.__hookDecorator(key);
@@ -153,7 +153,7 @@ export function DapiMixin<DEPENDENCIES, DAPI extends DapiFns<DEPENDENCIES>, T ex
 
       const command = this.__definition.fns[key];
 
-      this.__facade[key] = (...params: ParamsExtract<DAPI[typeof key], [DEPENDENCIES]>) => {
+      this.__facade[key] = (...params: ExtractFirstParam<DAPI[typeof key]>) => {
         return command.call(this, this.__deps, ...params);
       };
 
@@ -211,7 +211,7 @@ export function DapiMixin<DEPENDENCIES, DAPI extends DapiFns<DEPENDENCIES>, T ex
      * @param replacer An array of strings and numbers that acts as an approved list for selecting the object properties that will be stringified.
      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
      */
-    toJSON(...args: ParamsExtract<JSON['stringify'], [Parameters<JSON['stringify']>[0]]>) {
+    toJSON(...args: ExtractFirstParam<JSON['stringify']>) {
       return JSON.stringify(this.__definition, ...args);
     }
 

--- a/src/__tests__/typeUtils.test.ts
+++ b/src/__tests__/typeUtils.test.ts
@@ -10,7 +10,8 @@ import {
   PartialPick,
   TupleExtract,
   ParamsExtract,
-  RemoveNever
+  RemoveNever,
+  ExtractFirstParam
 } from '../types/utils';
 import {assertType} from '../types/assertType';
 
@@ -255,6 +256,32 @@ describe('type utils', () => {
       assertType<RemoveNever<obj>>({a: 1, b: 2});
       // @ts-expect-error - 'c' is not a key of the object after removing never values
       assertType<RemoveNever<obj>>({a: 1, b: 2, c: 3});
+    });
+  });
+
+  describe('ExtractFirstParam', () => {
+    it('should return a new Type that extracts from the beginning of the params tuple those that match EXTRACTED in the beginning', () => {
+      const fn = (a: number, b: string, c: boolean) => {};
+
+      type fnType = typeof fn;
+
+      assertType<ExtractFirstParam<fnType>>(['b', true]);
+    });
+
+    it('should work with functions of only one param', () => {
+      const fn = (a: number) => {};
+
+      type fnType = typeof fn;
+
+      assertType<ExtractFirstParam<fnType>>([]);
+    });
+
+    it('should work with functions of 0 params', () => {
+      const fn = () => {};
+
+      type fnType = typeof fn;
+
+      assertType<ExtractFirstParam<fnType>>([]);
     });
   });
 });

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -80,6 +80,12 @@ export type ParamsExtract<F extends AnyFunction, EXTRACTED extends AnyArgs = []>
   Parameters<F>,
   EXTRACTED
 >;
+/**
+ * Returns a new Type that extracts from the beginning of a Tuple of type TUPLE all the elements that match the specified type EXTRACTED in the beginning.
+ */
+export type ExtractFirstParam<F extends AnyFunction> = Parameters<F> extends []
+  ? []
+  : ParamsExtract<F, [Parameters<F>[0]]>;
 
 /**
  * Returns a new Type union with all the keys of type T that have values of type V.


### PR DESCRIPTION
…cting it

Instead of only extracting the first param of a dapi fn if its type is DEPENDENCIES, just assume it is and always extract the first parameter. We sacrificing type safety with flexibility. Not checking the dependecy type will allow library users to define deps of only the needed types on their dapi fns.